### PR TITLE
allow to specify per template item descriptor

### DIFF
--- a/scrapely/__init__.py
+++ b/scrapely/__init__.py
@@ -42,7 +42,7 @@ class Scraper(object):
 
     def scrape(self, url, encoding='utf-8'):
         page = self._get_page(url, encoding)
-        ex = InstanceBasedLearningExtractor(self.templates)
+        ex = InstanceBasedLearningExtractor((t, None) for t in self.templates)
         return ex.extract(page)[0]
 
     @staticmethod

--- a/scrapely/tests/test_extraction.py
+++ b/scrapely/tests/test_extraction.py
@@ -945,10 +945,10 @@ TEST_DATA = [
 
 class TestIbl(TestCase):
 
-    def _run_extraction(self, name, templates, page, extractors, expected_output):
+    def _run_extraction(self, name, templates, page, descriptor, expected_output):
         self.trace = None
         template_pages = [HtmlPage(None, {}, t) for t in templates]
-        extractor = InstanceBasedLearningExtractor(template_pages, extractors, True)
+        extractor = InstanceBasedLearningExtractor([(t, descriptor) for t in template_pages], True)
         actual_output, _ = extractor.extract(HtmlPage(None, {}, page))
         if not actual_output:
             if expected_output is None:

--- a/scrapely/tests/test_template.py
+++ b/scrapely/tests/test_template.py
@@ -23,7 +23,7 @@ class TemplateMakerTest(TestCase):
         tm = TemplateMaker(self.PAGE)
         tm.annotate('field1', best_match('text to annotate'))
         tpl = tm.get_template()
-        ex = InstanceBasedLearningExtractor([tpl])
+        ex = InstanceBasedLearningExtractor([(tpl, None)])
         self.assertEqual(ex.extract(self.PAGE)[0],
             [{u'field1': [u'Some text to annotate here']}])
 
@@ -31,7 +31,7 @@ class TemplateMakerTest(TestCase):
         tm = TemplateMaker(self.PAGE)
         tm.annotate('field1', best_match('text to annotate'), best_match=False)
         tpl = tm.get_template()
-        ex = InstanceBasedLearningExtractor([tpl])
+        ex = InstanceBasedLearningExtractor([(tpl, None)])
         self.assertEqual(ex.extract(self.PAGE)[0],
             [{u'field1': [u'Some text to annotate here', u'Another text to annotate there']}])
 
@@ -39,7 +39,7 @@ class TemplateMakerTest(TestCase):
         tm = TemplateMaker(self.PAGE)
         tm.annotate('field1', best_match("and that's"), best_match=False)
         tpl = tm.get_template()
-        ex = InstanceBasedLearningExtractor([tpl])
+        ex = InstanceBasedLearningExtractor([(tpl, None)])
         self.assertEqual(ex.extract(self.PAGE)[0],
             [{u'field1': [u"More text with unpaired tag <img />and that's it"]}])
 

--- a/scrapely/tool.py
+++ b/scrapely/tool.py
@@ -87,7 +87,7 @@ class IblTool(cmd.Cmd):
         if assert_or_print(templates, "no templates available"):
             return
         page = get_page(url, templates[0].encoding)
-        ex = InstanceBasedLearningExtractor(templates)
+        ex = InstanceBasedLearningExtractor((t, None) for t in templates)
         pprint.pprint(ex.extract(page)[0])
 
     def default(self, line):


### PR DESCRIPTION
allow to specify per template item descriptor with a list of (template, descriptor) pairs in ibl extractor constructor argument, as agreed in chat with shane today.
