### PR TITLE
fix problem with some cases of variant extraction

### DIFF
--- a/scrapely/extraction/similarity.py
+++ b/scrapely/extraction/similarity.py
@@ -79,7 +79,7 @@ def longest_unique_subsequence(to_search, subsequence, range_start=0,
     return None, None
 
 def similar_region(extracted_tokens, template_tokens, labelled_region, 
-        range_start=0, range_end=None):
+        range_start=0, range_end=None, **kwargs):
     """Given a labelled section in a template, identify a similar region
     in the extracted tokens.
 
@@ -103,15 +103,17 @@ def similar_region(extracted_tokens, template_tokens, labelled_region,
     (rpi, pscore) = longest_unique_subsequence(reverse_tokens, reverse_prefix,
             data_length - range_end, data_length - range_start)
 
-    # None means nothing exracted. Index 0 means there cannot be a suffix.
+    # None means nothing extracted. Index 0 means there cannot be a suffix.
     if not rpi:
         return 0, None, None
     
     # convert to an index from the start instead of in reverse
     prefix_index = len(extracted_tokens) - rpi - 1
-
+ 
     if labelled_region.end_index is None:
         return pscore, prefix_index, None
+    elif kwargs.get("suffix_max_length", None) == 0:
+        return pscore, prefix_index, range_start + 1
 
     suffix = template_tokens[labelled_region.end_index:]
 
@@ -134,3 +136,4 @@ def similar_region(extracted_tokens, template_tokens, labelled_region,
     if match_index is None:
         return 0, None, None
     return (pscore + sscore, prefix_index, match_index)
+

--- a/scrapely/tests/test_extraction.py
+++ b/scrapely/tests/test_extraction.py
@@ -794,6 +794,104 @@ EXTRACT_PAGE25 = u"""
 </span>
 """
 
+ANNOTATED_PAGE26 = u"""
+<span>
+<br>
+<input type="radio" name="size" checked value='44'>
+<ins data-scrapy-annotate="{&quot;variant&quot;: 1, &quot;generated&quot;: true, 
+&quot;annotations&quot;: {&quot;content&quot;: &quot;name&quot;}}">"Large"</ins>
+<br>
+<input type="radio" name="size" checked value='45'>
+"X Large"
+<br>
+<input type="radio" name="size" checked value='46'>
+<ins data-scrapy-annotate="{&quot;variant&quot;: 2, &quot;generated&quot;: true, 
+&quot;annotations&quot;: {&quot;content&quot;: &quot;name&quot;}}">"XX Large"</ins>
+</span>
+"""
+
+EXTRACT_PAGE26 = u"""
+<span>
+<br>
+<input type="radio" name="size" checked value='44'>
+"Large"
+<br>
+<input type="radio" name="size" checked value='45'>
+"X Large"
+<br>
+<input type="radio" name="size" checked value='46'>
+"XX Large"
+</span>
+"""
+
+ANNOTATED_PAGE27 = u"""
+<span>
+<br>
+<input type="radio" name="size" checked value='44' data-scrapy-annotate="{&quot;variant&quot;: 1, &quot;generated&quot;: false,
+&quot;annotations&quot;: {&quot;value&quot;: &quot;site_id&quot;}}">
+<ins data-scrapy-annotate="{&quot;variant&quot;: 1, &quot;generated&quot;: true, 
+&quot;annotations&quot;: {&quot;content&quot;: &quot;name&quot;}}">"Large"</ins>
+<br>
+<input type="radio" name="size" checked value='45'>
+"X Large"
+<br>
+<input type="radio" name="size" checked value='46' data-scrapy-annotate="{&quot;variant&quot;: 2, &quot;generated&quot;: false,
+&quot;annotations&quot;: {&quot;value&quot;: &quot;site_id&quot;}}">
+<ins data-scrapy-annotate="{&quot;variant&quot;: 2, &quot;generated&quot;: true, 
+&quot;annotations&quot;: {&quot;content&quot;: &quot;name&quot;}}">"XX Large"</ins>
+</span>
+"""
+
+EXTRACT_PAGE27 = u"""
+<span>
+<br>
+<input type="radio" name="size" checked value='44'>
+"Large"
+<br>
+<input type="radio" name="size" checked value='45'>
+"X Large"
+<br>
+<input type="radio" name="size" checked value='46'>
+"XX Large"
+</span>
+"""
+
+ANNOTATED_PAGE28 = u"""
+<span>
+<br>
+<input type="radio" name="size" checked value='44' data-scrapy-annotate="{&quot;variant&quot;: 1, &quot;generated&quot;: false,
+&quot;annotations&quot;: {&quot;value&quot;: &quot;site_id&quot;}}">
+<ins data-scrapy-annotate="{&quot;variant&quot;: 1, &quot;generated&quot;: true, 
+&quot;annotations&quot;: {&quot;content&quot;: &quot;name&quot;}}">"Large"</ins>
+<br>
+<input type="radio" name="size" checked value='45'>
+"X Large"
+<br>
+<input type="radio" name="size" checked value='46' data-scrapy-annotate="{&quot;variant&quot;: 2, &quot;generated&quot;: false,
+&quot;annotations&quot;: {&quot;value&quot;: &quot;site_id&quot;}}">
+<ins data-scrapy-annotate="{&quot;variant&quot;: 2, &quot;generated&quot;: true, 
+&quot;annotations&quot;: {&quot;content&quot;: &quot;name&quot;}}">"XX Large"</ins>
+</span>
+<div data-scrapy-annotate="{&quot;variant&quot;: 0, &quot;generated&quot;: false,
+&quot;annotations&quot;: {&quot;content&quot;: &quot;price&quot;}}"">Price: 45</div>
+"""
+
+EXTRACT_PAGE28 = u"""
+<span>
+<br>
+<input type="radio" name="size" checked value='44'>
+"Large"
+<br>
+<input type="radio" name="size" checked value='45'>
+"X Large"
+<br>
+<input type="radio" name="size" checked value='46'>
+"XX Large"
+</span>
+<div>Price: 45</div>
+"""
+
+
 DEFAULT_DESCRIPTOR = ItemDescriptor('test', 
         'item test, removes tags from description attribute',
         [A('description', 'description field without tags', notags)])
@@ -1024,6 +1122,30 @@ TEST_DATA = [
     ),
     ('repeated partial annotation within same tag', [ANNOTATED_PAGE25], EXTRACT_PAGE25, DEFAULT_DESCRIPTOR,
             {"name": ['"Large"', '"X Large"', '"XX Large"']}
+    ),
+    ('repeated partial annotation within same tag, variants version', [ANNOTATED_PAGE26], EXTRACT_PAGE26, DEFAULT_DESCRIPTOR,
+            {"variants": [
+                {"name": ['"Large"']},
+                {"name": ['"X Large"']},
+                {"name": ['"XX Large"']}
+            ]}
+    ),
+    ('repeated partial annotation within same tag, variants version with more than one attribute',
+            [ANNOTATED_PAGE27], EXTRACT_PAGE27, DEFAULT_DESCRIPTOR,
+            {"variants": [
+                {"name": ['"Large"'], "site_id": ["44"]},
+                {"name": ['"X Large"'], "site_id": ["45"]},
+                {"name": ['"XX Large"'], "site_id": ["46"]}
+            ]}
+    ),
+    ('repeated partial annotation within same tag, variants version with more than one attribute, more annotations around',
+            [ANNOTATED_PAGE28], EXTRACT_PAGE28, DEFAULT_DESCRIPTOR, {
+                "price": ["Price: 45"],
+                "variants": [
+                    {"name": ['"Large"'], "site_id": ["44"]},
+                    {"name": ['"X Large"'], "site_id": ["45"]},
+                    {"name": ['"XX Large"'], "site_id": ["46"]}]
+            }
     ),
 ]
 


### PR DESCRIPTION
avoid similarity mismatch when extracting last variant, for certain cases when suffix of the firt annotation is not the same as the suffix of the last variant (repeated extractor uses the first annotation).
