### PR TITLE
avoid false positives when extracted item is empty and descriptor has no required attribute

### DIFF
--- a/scrapely/descriptor.py
+++ b/scrapely/descriptor.py
@@ -40,7 +40,7 @@ class ItemDescriptor(object):
         """simply checks that all mandatory attributes are present"""
         variant_attrs = set(chain(*
             [v.keys() for v in item.get('variants', [])]))
-        return all([(name in item or name in variant_attrs) \
+        return item and all([(name in item or name in variant_attrs) \
                 for name in self._required_attributes])
 
     def get_required_attributes(self):


### PR DESCRIPTION
avoid false positives when extracted item is empty and descriptor has no required attributes. Also fixed extraction test code because previous one was masking the problem
