### PR TITLE
Some usability improvements for the cmdline tool

### DIFF
--- a/scrapely/tool.py
+++ b/scrapely/tool.py
@@ -125,7 +125,7 @@ class IblTool(cmd.Cmd):
         templates = self._load_templates()
         try:
             return templates[int(template_id)]
-        except:
+        except (IndexError, ValueError):
             print('Could not load template: %s' % template_id)
 
     def _load_templates(self):


### PR DESCRIPTION
I was playing around with scrapely cmdline tool, and I found out that it does not forgive an user error very much. =)
Here is my attempt to improve things a little bit.

Summary of the changes:

1. Changed all commands to a descriptive form, keeping previous command names as aliases. As the `cmd` module has some basic autocomplete, long descriptive names work better specially for the first-time user.
2. Alert the user when he forgets to provide a *template_id* instead of exiting the session
3. Attempts to fix incomplete URLs like `www.example.com` instead of `http://www.example.com`
4. Removed test command method, keeping backwards compatibility using an alias for the annotate command (which does the same thing when no field name is given).

This is a bit rough, but it should help to improve things a little.
Please let me know if you have any suggestion for improvements.