### PR TITLE
Fixes #61

### DIFF
--- a/scrapely/extraction/regionextract.py
+++ b/scrapely/extraction/regionextract.py
@@ -306,8 +306,8 @@ class RecordExtractor(object):
             u'<h1>name</h1> <p>description</p>')
     >>> basic_extractors = map(BasicTypeExtractor, template.annotations)
     >>> ex = RecordExtractor.apply(template, basic_extractors)[0]
-    >>> ex.extract(page)
-    [{u'description': [u'description'], u'name': [u'name']}]
+    >>> ex.extract(page) == [{u'description': [u'description'], u'name': [u'name']}]
+    True
     """
     
     def __init__(self, extractors, template_tokens):


### PR DESCRIPTION
Due to the fact that the order of the results of a dict can be unpredictable, this was failing. This commit changes the type of check to workaround this problem.
