### PR TITLE
formatting cleanups

### DIFF
--- a/scrapely/__init__.py
+++ b/scrapely/__init__.py
@@ -7,6 +7,7 @@ from scrapely.htmlpage import HtmlPage, page_to_dict, url_to_page
 from scrapely.template import TemplateMaker, best_match
 from scrapely.extraction import InstanceBasedLearningExtractor
 
+
 class Scraper(object):
 
     def __init__(self, templates=None):

--- a/scrapely/descriptor.py
+++ b/scrapely/descriptor.py
@@ -5,6 +5,7 @@ from itertools import chain
 
 from scrapely.extractors import text
 
+
 class FieldDescriptor(object):
     """description of a scraped attribute"""
     __slots__ = ('name', 'description', 'extractor', 'required')
@@ -17,6 +18,7 @@ class FieldDescriptor(object):
 
     def __str__(self):
         return "FieldDescriptor(%s)" % self.name
+
 
 class ItemDescriptor(object):
     """Simple auto scraping item descriptor.

--- a/scrapely/extraction/__init__.py
+++ b/scrapely/extraction/__init__.py
@@ -19,7 +19,7 @@ Main departures from the original algorithm:
 from operator import itemgetter
 from .pageparsing import parse_template, parse_extraction_page
 from .pageobjects import TokenDict
-from .regionextract import (BasicTypeExtractor, TraceExtractor, RepeatedDataExtractor, \
+from .regionextract import (BasicTypeExtractor, TraceExtractor, RepeatedDataExtractor,
                             AdjacentVariantExtractor, RecordExtractor, TemplatePageExtractor)
 
 
@@ -27,6 +27,14 @@ class InstanceBasedLearningExtractor(object):
     """Implementation of the instance based learning algorithm to
     extract data from web pages.
     """
+    _extractor_classes = [
+        RepeatedDataExtractor,
+        AdjacentVariantExtractor,
+        RepeatedDataExtractor,
+        AdjacentVariantExtractor,
+        RepeatedDataExtractor,
+        RecordExtractor,
+    ]
 
     def __init__(self, td_pairs, trace=False, apply_extrarequired=True):
         """Initialise this extractor
@@ -49,8 +57,10 @@ class InstanceBasedLearningExtractor(object):
         """
         self.token_dict = TokenDict()
         parsed_plus_tdpairs = [(parse_template(self.token_dict, td[0]), td) for td in td_pairs]
-        parsed_plus_epages = [(p, parse_extraction_page(self.token_dict, td[0]), td) for p, td \
-               in parsed_plus_tdpairs if _annotation_count(p)]
+        parsed_plus_epages = (
+            (p, parse_extraction_page(self.token_dict, td[0]), td)
+            for p, td in parsed_plus_tdpairs if _annotation_count(p)
+        )
         parsed_tdpairs = map(itemgetter(0, 2), parsed_plus_epages)
 
         modified_parsed_tdpairs = []
@@ -66,12 +76,16 @@ class InstanceBasedLearningExtractor(object):
                         descriptor.attribute_map[attr].required = True
             modified_parsed_tdpairs.append((parsed, (t, descriptor)))
         # templates with more attributes are considered first
-        sorted_tdpairs = sorted(modified_parsed_tdpairs, \
-                key=lambda x: _annotation_count(itemgetter(0)(x)), reverse=True)
-        self.extraction_trees = [self.build_extraction_tree(p, td[1],
-            trace) for p, td in sorted_tdpairs]
-        self.validated = dict((td[0].page_id, td[1].validated if td[1] else \
-                self._filter_not_none) for _, td in sorted_tdpairs)
+        sorted_tdpairs = sorted(modified_parsed_tdpairs,
+                key=lambda x: _annotation_count(x[0]), reverse=True)
+        self.extraction_trees = [
+            self.build_extraction_tree(p, td[1], trace)
+            for p, td in sorted_tdpairs
+        ]
+        self.validated = dict(
+            (td[0].page_id, td[1].validated if td[1] else self._filter_not_none)
+            for _, td in sorted_tdpairs
+        )
 
     def build_extraction_tree(self, template, type_descriptor, trace=True):
         """Build a tree of region extractors corresponding to the
@@ -81,8 +95,7 @@ class InstanceBasedLearningExtractor(object):
         extractors = BasicTypeExtractor.create(template.annotations, attribute_map)
         if trace:
             extractors = TraceExtractor.apply(template, extractors)
-        for cls in (RepeatedDataExtractor, AdjacentVariantExtractor, RepeatedDataExtractor, AdjacentVariantExtractor, RepeatedDataExtractor,
-                    RecordExtractor):
+        for cls in self._extractor_classes:
             extractors = cls.apply(template, extractors)
             if trace:
                 extractors = TraceExtractor.apply(template, extractors)
@@ -116,6 +129,7 @@ class InstanceBasedLearningExtractor(object):
     @staticmethod
     def _filter_not_none(items):
         return [d for d in items if d is not None]
+
 
 def _annotation_count(template):
     return len(template.annotations)

--- a/scrapely/extraction/pageobjects.py
+++ b/scrapely/extraction/pageobjects.py
@@ -9,9 +9,11 @@ from numpy import array, ndarray
 
 from scrapely.htmlpage import HtmlTagType, HtmlPageRegion, HtmlPageParsedRegion
 
+
 class TokenType(HtmlTagType):
     """constants for token types"""
     WORD = 0
+
 
 class TokenDict(object):
     """Mapping from parse tokens to integers
@@ -66,6 +68,7 @@ class TokenDict(object):
         templates = ["%s", "<%s>", "</%s>", "<%s/>"]
         return templates[tid >> 24] % self.find_token(tid)
 
+
 class PageRegion(object):
     """A region in a page, defined by a start and end index"""
 
@@ -82,6 +85,7 @@ class PageRegion(object):
     def __repr__(self):
         return str(self)
 
+
 class FragmentedHtmlPageRegion(HtmlPageParsedRegion, HtmlPageRegion):
     """An HtmlPageRegion consisting of possibly non-contiguous sub-regions"""
     def __new__(cls, htmlpage, regions):
@@ -95,6 +99,7 @@ class FragmentedHtmlPageRegion(HtmlPageParsedRegion, HtmlPageRegion):
     @property
     def parsed_fragments(self):
         return chain(*(r.parsed_fragments for r in self.regions))
+
 
 class Page(object):
     """Basic representation of a page. This consists of a reference to a
@@ -110,6 +115,7 @@ class Page(object):
         if not isinstance(page_tokens, ndarray):
             page_tokens = array(page_tokens)
         self.page_tokens = page_tokens
+
 
 class TemplatePage(Page):
     __slots__ = ('annotations', 'id', 'ignored_regions', 'extra_required_attrs')
@@ -132,6 +138,7 @@ class TemplatePage(Page):
             summary.append(text)
         return "TemplatePage\n============\nTokens: (index, token)\n%s\nAnnotations: %s\n" % \
                 ('\n'.join(summary), '\n'.join(map(str, self.annotations)))
+
 
 class ExtractionPage(Page):
     """Parsed data belonging to a web page upon which we wish to perform
@@ -183,6 +190,7 @@ class ExtractionPage(Page):
             summary.append(text)
         return "ExtractionPage\n==============\nTokens: %s\n\nRaw text: %s\n\n" \
                 % ('\n'.join(summary), self.htmlpage.body)
+
 
 class AnnotationText(object):
     __slots__ = ('start_text', 'follow_text')

--- a/scrapely/extraction/pageparsing.py
+++ b/scrapely/extraction/pageparsing.py
@@ -11,6 +11,7 @@ from scrapely.htmlpage import HtmlTagType, HtmlTag, HtmlPage
 from scrapely.extraction.pageobjects import (AnnotationTag,
     TemplatePage, ExtractionPage, AnnotationText, TokenDict, FragmentedHtmlPageRegion)
 
+
 def parse_strings(template_html, extraction_html):
     """Create a template and extraction page from raw strings
 
@@ -22,17 +23,20 @@ def parse_strings(template_html, extraction_html):
     return (parse_template(t, template_page),
             parse_extraction_page(t, extraction_page))
 
+
 def parse_template(token_dict, template_html):
     """Create an TemplatePage object by parsing the annotated html"""
     parser = TemplatePageParser(token_dict)
     parser.feed(template_html)
     return parser.to_template()
 
+
 def parse_extraction_page(token_dict, page_html):
     """Create an ExtractionPage object by parsing the html"""
     parser = ExtractionPageParser(token_dict)
     parser.feed(page_html)
     return parser.to_extraction_page()
+
 
 class InstanceLearningParser(object):
     """Base parser for instance based learning algorithm
@@ -64,6 +68,7 @@ class InstanceLearningParser(object):
 
     def handle_tag(self, html_tag, index):
         pass
+
 
 _END_UNPAIREDTAG_TAGS = ["form", "div", "p", "table", "tr", "td"]
 _AUTO_CLOSE_TAGS_ON_OPEN = {
@@ -316,6 +321,7 @@ class TemplatePageParser(InstanceLearningParser):
         """create a TemplatePage from the data fed to this parser"""
         return TemplatePage(self.html_page, self.token_dict, self.token_list, self.annotations,
                 self.html_page.page_id, self.ignored_regions, self.extra_required_attrs)
+
 
 class ExtractionPageParser(InstanceLearningParser):
     """Parse an HTML page for extraction using the instance based learning

--- a/scrapely/extraction/regionextract.py
+++ b/scrapely/extraction/regionextract.py
@@ -50,6 +50,7 @@ def labelled_element(obj):
     """
     return getattr(obj, 'annotation', obj)
 
+
 def _compose(f, g):
     """given unary functions f and g, return a function that computes f(g(x))
     """
@@ -57,6 +58,7 @@ def _compose(f, g):
         ret = g(x)
         return f(ret) if ret is not None else None
     return _exec
+
 
 class BasicTypeExtractor(object):
     """The BasicTypeExtractor extracts single attributes corresponding to
@@ -283,9 +285,11 @@ class RepeatedDataExtractor(object):
     def __str__(self):
         return "Repeat(%s)" % self.extractor
 
+
 class TransposedDataExtractor(object):
     """ """
     pass
+
 
 _namef = operator.itemgetter(0)
 _valuef = operator.itemgetter(1)
@@ -300,6 +304,7 @@ def attrs2dict(attributes):
     """
     grouped_data = groupby(sorted(attributes, key=_namef), _namef)
     return dict((name, list(map(_valuef, data))) for (name, data)  in grouped_data)
+
 
 class RecordExtractor(object):
     """The RecordExtractor will extract records given annotations.
@@ -447,6 +452,7 @@ class RecordExtractor(object):
             return "%s[\n%s\n]" % (self.__class__.__name__, template_data)
         return "%s[none]" % (self.__class__.__name__)
 
+
 class AdjacentVariantExtractor(RecordExtractor):
     """Extractor for variants
 
@@ -484,6 +490,7 @@ class AdjacentVariantExtractor(RecordExtractor):
 
     def __repr__(self):
         return str(self)
+
 
 class TraceExtractor(object):
     """Extractor that wraps other extractors and prints an execution
@@ -559,6 +566,7 @@ extracted
     def __repr__(self):
         return "Trace(%s)" % repr(self.traced)
 
+
 class TemplatePageExtractor(object):
     """Top level extractor for a template page"""
 
@@ -583,6 +591,7 @@ class TemplatePageExtractor(object):
 
     def __str__(self):
         return str(self.extractors)
+
 
 # Based on nltk's WordPunctTokenizer
 _tokenize = re.compile(r'\w+|[^\w\s]+', re.UNICODE | re.MULTILINE | re.DOTALL).findall

--- a/scrapely/extraction/regionextract.py
+++ b/scrapely/extraction/regionextract.py
@@ -195,6 +195,7 @@ class BasicTypeExtractor(object):
                 (self.annotation.start_index, self.annotation.end_index))
         return ''.join(messages)
 
+
 class RepeatedDataExtractor(object):
     """Data extractor for handling repeated data"""
 

--- a/scrapely/extraction/similarity.py
+++ b/scrapely/extraction/similarity.py
@@ -74,7 +74,7 @@ def longest_unique_subsequence(to_search, subsequence, range_start=0,
 
     # the comparison to startval ensures only matches of length >= 1 and
     # reduces the number of calls to the common_length function
-    matches = ((i, common_prefix_length(to_search[i:], subsequence)) \
+    matches = ((i, common_prefix_length(to_search[i:], subsequence))
         for i in xrange(range_start, range_end) if startval == to_search[i])
     best2 = nlargest(2, matches, key=itemgetter(1))
     # if there is a single unique best match, return that
@@ -106,7 +106,7 @@ def first_longest_subsequence(to_search, subsequence, range_start=0, range_end=N
 
     # the comparison to startval ensures only matches of length >= 1 and
     # reduces the number of calls to the common_length function
-    matches = [(i, common_prefix_length(to_search[i:], subsequence)) \
+    matches = [(i, common_prefix_length(to_search[i:], subsequence))
         for i in xrange(range_start, range_end) if startval == to_search[i]]
 
     if not matches:

--- a/scrapely/extraction/similarity.py
+++ b/scrapely/extraction/similarity.py
@@ -6,6 +6,7 @@ from six.moves import zip as izip, xrange
 from operator import itemgetter
 from heapq import nlargest
 
+
 def common_prefix_length(a, b):
     """Calculate the length of the common prefix in both sequences passed.
 
@@ -23,6 +24,7 @@ def common_prefix_length(a, b):
             return i
     return i + 1
 
+
 def common_prefix(*sequences):
     """determine the common prefix of all sequences passed
 
@@ -38,6 +40,7 @@ def common_prefix(*sequences):
         else:
             break
     return prefix
+
 
 def longest_unique_subsequence(to_search, subsequence, range_start=0,
         range_end=None):
@@ -79,6 +82,7 @@ def longest_unique_subsequence(to_search, subsequence, range_start=0,
         return best2[0]
     return None, None
 
+
 def first_longest_subsequence(to_search, subsequence, range_start=0, range_end=None):
     """Find the first longest subsequence of the items in a list or array.
 
@@ -109,6 +113,7 @@ def first_longest_subsequence(to_search, subsequence, range_start=0, range_end=N
         return None, None
     # secondary sort on position and prefer the smaller one (near)
     return max(matches, key=lambda x: (x[1], -x[0]))
+
 
 def similar_region(extracted_tokens, template_tokens, labelled_region,
         range_start=0, range_end=None, best_match=longest_unique_subsequence, **kwargs):
@@ -168,4 +173,3 @@ def similar_region(extracted_tokens, template_tokens, labelled_region,
     if match_index is None:
         return 0, None, None
     return (pscore + sscore, prefix_index, match_index)
-

--- a/scrapely/extractors.py
+++ b/scrapely/extractors.py
@@ -52,11 +52,13 @@ _TAGS_TO_REPLACE = {
 # (overrides tags_to_keep and tags_to_replace)
 _TAGS_TO_PURGE = ('script', 'img', 'input')
 
+
 def htmlregion(text):
     """convenience function to make an html region from text.
     This is useful for testing
     """
     return HtmlPage(body=text).subregion()
+
 
 def notags(region, tag_replace=u' '):
     """Removes all html tags"""
@@ -66,6 +68,7 @@ def notags(region, tag_replace=u' '):
     page = region.htmlpage
     data = [page.fragment_data(f) for f in fragments if not isinstance(f, HtmlTag)]
     return tag_replace.join(data)
+
 
 def text(region):
     """Converts HTML to text. There is no attempt at formatting other than
@@ -97,6 +100,7 @@ def text(region):
     """
     text = remove_entities(region.text_content, encoding=region.htmlpage.encoding)
     return _WS.sub(u' ', text).strip()
+
 
 def safehtml(region, allowed_tags=_TAGS_TO_KEEP, replace_tags=_TAGS_TO_REPLACE,
     tags_to_purge=_TAGS_TO_PURGE):
@@ -170,6 +174,7 @@ def safehtml(region, allowed_tags=_TAGS_TO_KEEP, replace_tags=_TAGS_TO_REPLACE,
         _process_tag, tags_to_purge)) + ["</%s>" % t for t in reversed(tagstack)]
     return u''.join(chunks).strip()
 
+
 def _process_markup(region, textf, tagf, tags_to_purge=_TAGS_TO_PURGE):
     fragments = getattr(region, 'parsed_fragments', None)
     if fragments is None:
@@ -199,9 +204,11 @@ def _process_markup(region, textf, tagf, tags_to_purge=_TAGS_TO_PURGE):
             if text:
                 yield text
 
+
 def html(pageregion):
     """A page region is already html, so this is the identity function"""
     return pageregion
+
 
 def contains_any_numbers(txt):
     """text that must contain at least one number
@@ -212,10 +219,12 @@ def contains_any_numbers(txt):
     if _NUMBER_RE.search(txt) is not None:
         return txt
 
+
 def contains_prices(txt):
     """text must contain a number that is not joined to text"""
     if _PRICE_NUMBER_RE.findall(txt) is not None:
         return txt
+
 
 def contains_numbers(txt, count=1):
     """Must contain a certain amount of numbers
@@ -227,6 +236,7 @@ def contains_numbers(txt, count=1):
     numbers = _NUMBER_RE.findall(txt)
     if len(numbers) == count:
         return txt
+
 
 def extract_number(txt):
     """Extract a numeric value.
@@ -245,6 +255,7 @@ def extract_number(txt):
     numbers = _NUMBER_RE.findall(txt)
     if len(numbers) == 1:
         return numbers[0]
+
 
 def extract_price(txt):
     """
@@ -277,6 +288,7 @@ def extract_price(txt):
         value = "".join(parts + [decimalpart]).replace(",", "")
         return value
 
+
 def url(txt):
     """convert text to a url
 
@@ -285,6 +297,7 @@ def url(txt):
     txt = txt.strip("\t\r\n '\"")
     if txt:
         return txt
+
 
 def image_url(txt):
     """convert text to a url
@@ -340,6 +353,7 @@ def image_url(txt):
     """
     imgurl = extract_image_url(txt)
     return [safe_url_string(remove_entities(url(imgurl)))] if imgurl else None
+
 
 def extract_image_url(txt):
     txt = url(txt)

--- a/scrapely/htmlpage.py
+++ b/scrapely/htmlpage.py
@@ -13,6 +13,7 @@ from six.moves.urllib.request import urlopen
 from copy import deepcopy
 from w3lib.encoding import html_to_unicode
 
+
 def url_to_page(url, encoding=None, default_encoding='utf-8'):
     """Fetch a URL, using python urllib2, and return an HtmlPage object.
 
@@ -43,6 +44,7 @@ def url_to_page(url, encoding=None, default_encoding='utf-8'):
         body = body_str.decode(encoding)
     return HtmlPage(fh.geturl(), headers=dict(info.items()), body=body, encoding=encoding)
 
+
 def dict_to_page(jsonpage, body_key='body'):
     """Create an HtmlPage object from a dict object.
 
@@ -57,6 +59,7 @@ def dict_to_page(jsonpage, body_key='body'):
     encoding = jsonpage.get('encoding', 'utf-8')
     return HtmlPage(url, headers, body, page_id, encoding)
 
+
 def page_to_dict(page, body_key='body'):
     """Create a dict from the given HtmlPage
 
@@ -70,6 +73,7 @@ def page_to_dict(page, body_key='body'):
         'page_id': page.page_id,
         'encoding': page.encoding,
     }
+
 
 class HtmlPage(object):
     """HtmlPage
@@ -110,6 +114,7 @@ class HtmlPage(object):
         """portion of the body corresponding to the HtmlDataFragment"""
         return self.body[data_fragment.start:data_fragment.end]
 
+
 class TextPage(HtmlPage):
     """An HtmlPage with one unique HtmlDataFragment, needed to have a
     convenient text with same interface as html page but avoiding unnecesary
@@ -118,6 +123,7 @@ class TextPage(HtmlPage):
         self._body = text
         self.parsed_body = [HtmlDataFragment(0, len(self._body), True)]
     body = property(lambda x: x._body, _set_body, doc="raw text for the page")
+
 
 class HtmlPageRegion(six.text_type):
     """A Region of an HtmlPage that has been extracted
@@ -135,6 +141,7 @@ class HtmlPageRegion(six.text_type):
     @property
     def text_content(self):
         return self
+
 
 class HtmlPageParsedRegion(HtmlPageRegion):
     """A region of an HtmlPage that has been extracted
@@ -186,6 +193,7 @@ class HtmlTagType(object):
     CLOSE_TAG = 2
     UNPAIRED_TAG = 3
 
+
 class HtmlDataFragment(object):
     __slots__ = ('start', 'end', 'is_text_content')
 
@@ -199,6 +207,7 @@ class HtmlDataFragment(object):
 
     def __repr__(self):
         return str(self)
+
 
 class HtmlTag(HtmlDataFragment):
     __slots__ = ('tag_type', 'tag', 'attributes')
@@ -216,6 +225,7 @@ class HtmlTag(HtmlDataFragment):
     def __repr__(self):
         return str(self)
 
+
 _ATTR = "((?:[^=/<>\s]|/(?!>))+)(?:\s*=(?:\s*\"(.*?)\"|\s*'(.*?)'|([^>\s]+))?)?"
 _TAG = "<(\/?)(\w+(?::\w+)?)((?:\s*" + _ATTR + ")+\s*|\s*)(\/?)>?"
 _DOCTYPE = r"<!DOCTYPE.*?>"
@@ -226,6 +236,7 @@ _ATTR_REGEXP = re.compile(_ATTR, re.I | re.DOTALL)
 _HTML_REGEXP = re.compile("%s|%s|%s" % (_COMMENT, _SCRIPT, _TAG), re.I | re.DOTALL)
 _DOCTYPE_REGEXP = re.compile("(?:%s)" % _DOCTYPE)
 _COMMENT_REGEXP = re.compile(_COMMENT, re.DOTALL)
+
 
 def parse_html(text):
     """Higher level html parser. Calls lower level parsers and joins sucesive
@@ -256,6 +267,7 @@ def parse_html(text):
     if prev_end < textlen:
         yield HtmlDataFragment(prev_end, textlen, True)
 
+
 def _parse_script(match):
     """parse a <script>...</script> region matched by _HTML_REGEXP"""
     open_text, content, close_text = match.groups()[1:4]
@@ -279,6 +291,7 @@ def _parse_script(match):
         if open_tag.end + start_pos < close_tag.start:
             yield HtmlDataFragment(open_tag.end + start_pos, close_tag.start)
     yield close_tag
+
 
 def _parse_tag(match):
     """

--- a/scrapely/template.py
+++ b/scrapely/template.py
@@ -3,14 +3,18 @@ import json
 
 from scrapely.htmlpage import HtmlTag, HtmlTagType
 
+
 class AnnotationError(Exception):
     pass
+
 
 class FragmentNotFound(AnnotationError):
     pass
 
+
 class FragmentAlreadyAnnotated(AnnotationError):
     pass
+
 
 class TemplateMaker(object):
 
@@ -98,6 +102,7 @@ def best_match(text):
         else:
             return 0.0
     return func
+
 
 def _enclosing_tags(htmlpage, index):
     f = htmlpage.parsed_body[index]

--- a/scrapely/tool.py
+++ b/scrapely/tool.py
@@ -9,6 +9,7 @@ from scrapely.htmlpage import HtmlPage, page_to_dict, url_to_page
 from scrapely.template import TemplateMaker, best_match
 from scrapely.extraction import InstanceBasedLearningExtractor
 
+
 class IblTool(cmd.Cmd):
 
     prompt = 'scrapely> '
@@ -149,6 +150,7 @@ def parse_at(ta_line):
     p.add_option('-e', '--encoding', help='page encoding')
     return p.parse_args(shlex.split(ta_line))
 
+
 def apply_criteria(criteria, tm):
     """Apply the given criteria object to the given template"""
     func = best_match(criteria.text) if criteria.text else lambda x, y: False
@@ -160,13 +162,16 @@ def apply_criteria(criteria, tm):
             sel = []
     return sel
 
+
 def remove_annotation(text):
     return re.sub(u' ?data-scrapy-annotate=".*?"', '', text)
+
 
 def assert_or_print(condition, text):
     if not condition:
         sys.stderr.write(text + os.linesep)
         return True
+
 
 def args_to_file(args):
     s = []
@@ -178,6 +183,7 @@ def args_to_file(args):
                 a = '"%s"' % a
         s.append(a)
     return StringIO(' '.join(s))
+
 
 def main():
     if len(sys.argv) == 1:


### PR DESCRIPTION
* added pep8-compliant line separators;
* reformatted some of list comprehensions - now result tuples are not split by a newline.

I tried to keep changes minimal to avoid hurting anyone's feelings :)
See also: https://github.com/scrapy/scrapely/pull/63 <- it is a bit more ambitious.