### PR TITLE
rename some variables in scrapely.regionextract

### DIFF
--- a/scrapely/extraction/regionextract.py
+++ b/scrapely/extraction/regionextract.py
@@ -388,11 +388,11 @@ class RecordExtractor(object):
                 ignored_regions.append(region)
         extracted_data = []
         # end_index is inclusive, but similar_region treats it as exclusive
-        end_region = None if end_index is None else end_index + 1
+        end_index_exclusive = None if end_index is None else end_index + 1
         labelled = labelled_element(first_region)
         score, pindex, sindex = \
             similar_region(page.page_tokens, self.template_tokens,
-                labelled, start_index, end_region, self.best_match, **kwargs)
+                labelled, start_index, end_index_exclusive, self.best_match, **kwargs)
         if score > 0:
             if isinstance(labelled, AnnotationTag):
                 similar_ignored_regions = []

--- a/scrapely/extraction/regionextract.py
+++ b/scrapely/extraction/regionextract.py
@@ -37,7 +37,7 @@ __all__ = ['BasicTypeExtractor',
            'labelled_element']
 
 
-def _int_cmp(a, b, op):
+def _int_cmp(a, op, b):
     op = getattr(operator, op)
     a = -float('inf') if a is None else a
     b = -float('inf') if b is None else b
@@ -114,8 +114,8 @@ class BasicTypeExtractor(object):
 
     def _extract_content(self, extraction_page, start_index, end_index, ignored_regions=None, **kwargs):
         """extract content between annotation indexes"""
-        if ignored_regions and (_int_cmp(start_index, ignored_regions[0].start_index, 'le') and
-                                _int_cmp(end_index, ignored_regions[-1].end_index, 'ge')):
+        if ignored_regions and (_int_cmp(start_index, 'le', ignored_regions[0].start_index) and
+                                _int_cmp(end_index, 'ge', ignored_regions[-1].end_index)):
             starts = [start_index] + [i.end_index for i in ignored_regions if i.end_index is not None]
             ends = [i.start_index for i in ignored_regions]
             if starts[-1] is not None:
@@ -371,17 +371,14 @@ class RecordExtractor(object):
         ignored_regions = ignored_regions or []
         current_extractor, following_extractors = extractors[0], extractors[1:]
         while (following_extractors and
-               _int_cmp(labelled_element(following_extractors[0]).start_index,
-                        labelled_element(current_extractor).end_index, 'lt')):
+               _int_cmp(labelled_element(following_extractors[0]).start_index, 'lt',
+                        labelled_element(current_extractor).end_index)):
             ex = following_extractors.pop(0)
             labelled = labelled_element(ex)
             if (isinstance(labelled, AnnotationTag) or
                 (nested_regions and
-                 _int_cmp(labelled_element(nested_regions[-1]).start_index,
-                          labelled.start_index, 'lt') and
-                 _int_cmp(labelled.start_index,
-                          labelled_element(nested_regions[-1]).end_index,
-                          'lt'))):
+                 _int_cmp(labelled_element(nested_regions[-1]).start_index, 'lt', labelled.start_index) and
+                 _int_cmp(labelled.start_index, 'lt', labelled_element(nested_regions[-1]).end_index))):
                 nested_regions.append(ex)
             else:
                 ignored_regions.append(ex)


### PR DESCRIPTION
I've tried to make code a bit more readable by renaming some variables:

* https://github.com/scrapy/scrapely/blob/664453340e072d2d9db967bc38ff17b2d7b4ef42/scrapely/extraction/regionextract.py#L365 'region_elements' argument doesn't contain PageRegion objects - it usually contains RecordExtractor, RepeatedDataExtractor, AdjacentVariantExtractor, etc., so it is renamed to 'extractors';
* https://github.com/scrapy/scrapely/blob/664453340e072d2d9db967bc38ff17b2d7b4ef42/scrapely/extraction/regionextract.py#L391 - variable is named 'end_region', but it contains neither page region nor an extractor object - it is an integer index, so it is renamed to 'end_index_exclusive'.