### PR TITLE
Attributes lazy loading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python: 2.7
 env:
-- TOXENV=py26
 - TOXENV=py27
 - TOXENV=py33
 - TOXENV=py34

--- a/scrapely/htmlpage.py
+++ b/scrapely/htmlpage.py
@@ -229,7 +229,10 @@ class HtmlTag(HtmlDataFragment):
             for attr_match in _ATTR_REGEXP.findall(self._attr_text):
                 name = attr_match[0].lower()
                 values = [v for v in attr_match[1:] if v]
-                self._attributes[name] = values[0] if values else None
+                # According to HTML spec if attribute name is repeated only the
+                # first one is taken into account
+                if name not in self._attributes:
+                    self._attributes[name] = values[0] if values else None
         return self._attributes
 
     def __str__(self):

--- a/scrapely/htmlpage.py
+++ b/scrapely/htmlpage.py
@@ -210,13 +210,27 @@ class HtmlDataFragment(object):
 
 
 class HtmlTag(HtmlDataFragment):
-    __slots__ = ('tag_type', 'tag', 'attributes')
+    __slots__ = ('tag_type', 'tag', '_attributes', '_attr_text')
 
-    def __init__(self, tag_type, tag, attributes, start, end):
+    def __init__(self, tag_type, tag, attr_text, start, end):
         HtmlDataFragment.__init__(self, start, end)
         self.tag_type = tag_type
         self.tag = tag
-        self.attributes = attributes
+        if isinstance(attr_text, dict):
+            self._attributes = attr_text
+            self._attr_text = None
+        else: # defer loading attributes until necessary
+            self._attributes = {}
+            self._attr_text = attr_text
+
+    @property
+    def attributes(self):
+        if not self._attributes and self._attr_text:
+            for attr_match in _ATTR_REGEXP.findall(self._attr_text):
+                name = attr_match[0].lower()
+                values = [v for v in attr_match[1:] if v]
+                self._attributes[name] = values[0] if values else None
+        return self._attributes
 
     def __str__(self):
         return "<HtmlTag tag='%s' attributes={%s} type='%d' [%s:%s]>" % (self.tag, ', '.join(sorted\
@@ -309,8 +323,4 @@ def _parse_tag(match):
         else:
             tag_type = HtmlTagType.OPEN_TAG
         attributes = []
-        for attr_match in _ATTR_REGEXP.findall(attr_text):
-            name = attr_match[0].lower()
-            values = [v for v in attr_match[1:] if v]
-            attributes.append((name, values[0] if values else None))
-        return HtmlTag(tag_type, tag.lower(), dict(attributes), match.start(), match.end())
+        return HtmlTag(tag_type, tag.lower(), attr_text, match.start(), match.end())

--- a/tests/samples/samples_htmlpage_2.json
+++ b/tests/samples/samples_htmlpage_2.json
@@ -9061,7 +9061,7 @@
         {
                 "attributes": {
                         "onerror": null, 
-                        "src": "http://images.play.com/covers/8986420m.jpg", 
+                        "src": "http://images.play.com/SiteCSS/Play/Live1/img/proxy/02m.gif",
                         "alt": "Samsung Series 5 550 37&quot; LE37B550 / HD 1080p / Freeview / LCD TV (Black)", 
                         "style": "border-width:0px;height:170px;width:170px;"
                 }, 
@@ -13481,7 +13481,7 @@
         {
                 "attributes": {
                         "onerror": null, 
-                        "src": "http://images.play.com/covers/8986409s.jpg", 
+                        "src": "http://images.play.com/SiteCSS/Play/Live1/img/proxy/02s.gif",
                         "alt": "Samsung Series 5 550 32&quot; LE32B550 / HD 1080p / Freeview / LCD TV (Black)", 
                         "style": "height:85px;width:85px;border-width:0px;"
                 }, 
@@ -15324,7 +15324,7 @@
         {
                 "attributes": {
                         "onerror": null, 
-                        "src": "http://images.play.com/covers/8986397s.jpg", 
+                        "src": "http://images.play.com/SiteCSS/Play/Live1/img/proxy/02xs.gif",
                         "alt": "Samsung Series 4 450 32&quot; LE32B450 / HD Ready / Freeview / LCD TV (Black)", 
                         "style": "height:60px;width:60px;border-width:0px;", 
                         "class": "sideimageline"
@@ -18831,7 +18831,7 @@
         {
                 "attributes": {
                         "onerror": null, 
-                        "src": "http://images.play.com/covers/8839534s.jpg", 
+                        "src": "http://images.play.com/SiteCSS/Play/Live1/img/proxy/02xs.gif",
                         "alt": "Sony Bravia S Series 26&quot; 26S5500 HD Ready Freeview Widescreen LCD TV", 
                         "style": "height:60px;width:60px;border-width:0px;", 
                         "class": "sideimageline"


### PR DESCRIPTION
HtmlTag won't parse attributes until they are accessed. The reason is that most of the attributes are never used for extraction.