### PR TITLE
Add better python3 support #89

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.pyc
+*.c
+*.so
 .tox
 build
 dist

--- a/scrapely/__init__.py
+++ b/scrapely/__init__.py
@@ -1,4 +1,3 @@
-import urllib
 import json
 
 from w3lib.util import str_to_unicode

--- a/scrapely/extraction/regionextract.py
+++ b/scrapely/extraction/regionextract.py
@@ -13,15 +13,14 @@ from itertools import groupby, starmap
 
 from numpy import array
 
-from six import StringIO
-from six.moves import zip as izip, xrange
+from six.moves import zip as izip, xrange, StringIO
 
 from scrapely.descriptor import FieldDescriptor
 from scrapely.htmlpage import HtmlPageRegion
-from scrapely.extraction.similarity import (similar_region,
-    longest_unique_subsequence, common_prefix)
-from scrapely.extraction.pageobjects import (AnnotationTag,
-    PageRegion, FragmentedHtmlPageRegion)
+from scrapely.extraction.similarity import (
+    similar_region, longest_unique_subsequence, common_prefix)
+from scrapely.extraction.pageobjects import (
+    AnnotationTag, PageRegion, FragmentedHtmlPageRegion)
 
 _EXTRACT_HTML = lambda x: x
 _DEFAULT_DESCRIPTOR = FieldDescriptor('none', None)

--- a/scrapely/htmlpage.py
+++ b/scrapely/htmlpage.py
@@ -22,17 +22,19 @@ HtmlTagType = _htmlpage.HtmlTagType
 
 
 def url_to_page(url, encoding=None, default_encoding='utf-8'):
-    """Fetch a URL, using python urllib2, and return an HtmlPage object.
+    """Fetch a URL, using python urllib, and return an HtmlPage object.
 
-    The `url` may be a string, or a `urllib2.Request` object. The `encoding`
-    argument can be used to force the interpretation of the page encoding.
+    The `url` may be a string, or a `urllib.request.Request` object. The
+    `encoding` argument can be used to force the interpretation of the page
+    encoding.
 
-    Redirects are followed, and the `url` property of the returned HtmlPage object
-    is the url of the final page redirected to.
+    Redirects are followed, and the `url` property of the returned HtmlPage
+    object is the url of the final page redirected to.
 
-    If the encoding of the page is known, it can be passed as a keyword argument. If
-    unspecified, the encoding is guessed using `w3lib.encoding.html_to_unicode`.
-    `default_encoding` is used if the encoding cannot be determined.
+    If the encoding of the page is known, it can be passed as a keyword
+    argument. If unspecified, the encoding is guessed using
+    `w3lib.encoding.html_to_unicode`. `default_encoding` is used if the
+    encoding cannot be determined.
     """
     fh = urlopen(url)
     info = fh.info()

--- a/scrapely/tool.py
+++ b/scrapely/tool.py
@@ -1,9 +1,6 @@
 from __future__ import print_function
 import sys, os, re, cmd, shlex, optparse, json, pprint
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from six.moves import StringIO
 
 from scrapely.htmlpage import HtmlPage, page_to_dict, url_to_page
 from scrapely.template import TemplateMaker, best_match


### PR DESCRIPTION
Remove unused python2 only import.
Use six to import StringIO.
Ignore files generated by cython in gitignore.