### PR TITLE
Run tests with code coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 build
 dist
 scrapely.egg-info
+
+# coverage reports
+.coverage
+.coverage.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
 language: python
 python: 2.7
+
 env:
 - TOXENV=py27
 - TOXENV=py33
 - TOXENV=py34
+
 install:
 - pip install cython
-- pip install -U tox
+- pip install -U tox codecov
+
 script: tox
+
+after_success:
+  - codecov
+
 notifications:
   irc:
     use_notice: true

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,9 @@ deps =
 commands =
     pip install -e .
     nosetests \
+        --with-coverage \
+        --cover-package=scrapely \
+        --cover-branches \
         --with-doctest \
         --with-doctest-ignore-unicode \
         --doctest-options='+ELLIPSIS,+IGNORE_UNICODE' \


### PR DESCRIPTION
With codecov.io, the results are browsable at https://codecov.io/gh/scrapy/scrapely