### PR TITLE
Add GitHub Actions workflow for Python 3.10-3.14 testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install cython numpy w3lib six
+        pip install nose parameterized doctest-ignore-unicode coverage
+
+    - name: Build extensions
+      run: |
+        CYTHONIZE=1 python setup.py build_ext --inplace
+
+    - name: Install package
+      run: |
+        pip install -e .
+
+    - name: Run tests
+      run: |
+        nosetests \
+          --with-coverage \
+          --cover-package=scrapely \
+          --cover-branches \
+          --with-doctest \
+          --with-doctest-ignore-unicode \
+          --doctest-options='+ELLIPSIS,+IGNORE_UNICODE' \
+          scrapely tests


### PR DESCRIPTION
This adds a modern CI/CD workflow using GitHub Actions to test the package on Python 3.10, 3.11, 3.12, 3.13, and 3.14. The workflow:
- Runs on ubuntu-latest
- Builds Cython extensions
- Runs the full test suite with coverage and doctests
- Triggers on push and pull requests to master branch